### PR TITLE
Fix typo in .vimrc second comment

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -12,7 +12,7 @@ set hlsearch
 :nnoremap <CR> :nohlsearch<CR><CR>
 
 " Test comment
-" Second itestcomment
+" Second test comment
 " Remove sounds
 set noerrorbells
 set novisualbell


### PR DESCRIPTION
## Summary
Testing OpenAI Codex

Change:
- correct typo in second test comment in .vimrc

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a3a07ff97c832b95031409d6efb954