### PR TITLE
Ensure Homebrew shellenv runs before bundler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 install:
 	@command -v brew >/dev/null 2>&1 || /bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-	@eval "$$(brew --prefix)/bin/brew shellenv" && brew bundle install
+	@eval "$$(/opt/homebrew/bin/brew shellenv)"
+	@echo 'eval "$$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+	@brew bundle install
 
 clean:
 	brew bundle cleanup


### PR DESCRIPTION
## Summary
- evaluate Homebrew shellenv after install so `brew` is available
- append shellenv eval to `~/.zprofile`
- run Homebrew bundle after shellenv initialization

## Testing
- `make -n install`


------
https://chatgpt.com/codex/tasks/task_e_68a3b7a7c21c832b8ff7d15d46d6ea2f